### PR TITLE
Generate BibTeX references.

### DIFF
--- a/lib/cff/formatter/bibtex_formatter.rb
+++ b/lib/cff/formatter/bibtex_formatter.rb
@@ -48,9 +48,9 @@ module CFF
     def self.format_author(author)
       if author.is_a?(Person)
         output = []
-        output << author.given_names if present?(author.given_names)
         output << author.family_names if present?(author.family_names)
-        return output.join(' ')
+        output << author.given_names if present?(author.given_names)
+        return output.join(', ')
       end
 
       return author.name if author.is_a?(Entity)

--- a/lib/cff/formatter/bibtex_formatter.rb
+++ b/lib/cff/formatter/bibtex_formatter.rb
@@ -31,7 +31,7 @@ module CFF
       end
 
       sorted_values = values.sort.map { |key, value| pair(key: key, value: value) }
-      sorted_values.insert(0, '@misc{YourReferenceHere')
+      sorted_values.insert(0, "@misc{#{generate_reference(values)}")
 
       output = sorted_values.join(",\n")
       output << "\n}"
@@ -58,6 +58,14 @@ module CFF
 
     def self.combine_authors(authors)
       authors.join(' and ')
+    end
+
+    def self.generate_reference(fields)
+      author = fields['author'].split(',', 2)[0].tr(' -', '_')
+      title = fields['title'].split[0..2].map do |word|
+        word.tr('-$£%&()+!?/\\:;\'"~#', '')
+      end
+      [author, title, fields['year']].compact.join('_')
     end
   end
 end

--- a/test/cff_bibtex_formatter_test.rb
+++ b/test/cff_bibtex_formatter_test.rb
@@ -21,4 +21,27 @@ class CFFBibtexFormatterTest < Minitest::Test
     cff = CFF::Model.new(nil)
     assert_nil cff.to_bibtex
   end
+
+  def test_generate_reference
+    [
+      [
+        {
+          'author' => 'von Haines, Robert and Robert, Haines',
+          'title' => 'My Family and Other Animals',
+          'year' => '2021'
+        },
+        'von_Haines_My_Family_and_2021'
+      ],
+      [
+        {
+          'year' => nil,
+          'author' => 'An Organisation',
+          'title' => "Really?! 'Everyone' Disagrees?"
+        },
+        'An_Organisation_Really_Everyone_Disagrees'
+      ]
+    ].each do |fields, reference|
+      assert_equal(reference, ::CFF::BibtexFormatter.generate_reference(fields))
+    end
+  end
 end

--- a/test/converted/TUe-excellent-buildings_BSO-toolbox.bibtex
+++ b/test/converted/TUe-excellent-buildings_BSO-toolbox.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Sjonnie Boonstra and Hèrm Hofmeyer},
+author = {Boonstra, Sjonnie and Hofmeyer, Hèrm},
 doi = {10.5281/zenodo.3823893},
 month = {5},
 title = {BSO Toolbox},

--- a/test/converted/TUe-excellent-buildings_BSO-toolbox.bibtex
+++ b/test/converted/TUe-excellent-buildings_BSO-toolbox.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Boonstra_BSO_Toolbox_2020,
 author = {Boonstra, Sjonnie and Hofmeyer, Hèrm},
 doi = {10.5281/zenodo.3823893},
 month = {5},

--- a/test/converted/TUe-excellent-buildings_BSO-toolbox_invalid_date.bibtex
+++ b/test/converted/TUe-excellent-buildings_BSO-toolbox_invalid_date.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Sjonnie Boonstra and Hèrm Hofmeyer},
+author = {Boonstra, Sjonnie and Hofmeyer, Hèrm},
 doi = {10.5281/zenodo.3823893},
 title = {BSO Toolbox}
 }

--- a/test/converted/TUe-excellent-buildings_BSO-toolbox_invalid_date.bibtex
+++ b/test/converted/TUe-excellent-buildings_BSO-toolbox_invalid_date.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Boonstra_BSO_Toolbox,
 author = {Boonstra, Sjonnie and Hofmeyer, Hèrm},
 doi = {10.5281/zenodo.3823893},
 title = {BSO Toolbox}

--- a/test/converted/bjmorgan_bsym.bibtex
+++ b/test/converted/bjmorgan_bsym.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Benjamin J. Morgan},
+author = {Morgan, Benjamin J.},
 doi = {10.5281/zenodo.596912},
 title = {bsym},
 url = {https://github.com/bjmorgan/bsym}

--- a/test/converted/bjmorgan_bsym.bibtex
+++ b/test/converted/bjmorgan_bsym.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Morgan_bsym,
 author = {Morgan, Benjamin J.},
 doi = {10.5281/zenodo.596912},
 title = {bsym},

--- a/test/converted/citation-file-format_citation-file-format.bibtex
+++ b/test/converted/citation-file-format_citation-file-format.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Druskat_Citation_File_Format_2021,
 author = {Druskat, Stephan and Spaaks, Jurriaan H. and Chue Hong, Neil and Haines, Robert and Baker, James and Bliven, Spencer and Willighagen, Egon and Pérez-Suárez, David and Konovalov, Alexander},
 doi = {10.5281/zenodo.4751536},
 month = {5},

--- a/test/converted/citation-file-format_citation-file-format.bibtex
+++ b/test/converted/citation-file-format_citation-file-format.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Stephan Druskat and Jurriaan H. Spaaks and Neil Chue Hong and Robert Haines and James Baker and Spencer Bliven and Egon Willighagen and David Pérez-Suárez and Alexander Konovalov},
+author = {Druskat, Stephan and Spaaks, Jurriaan H. and Chue Hong, Neil and Haines, Robert and Baker, James and Bliven, Spencer and Willighagen, Egon and Pérez-Suárez, David and Konovalov, Alexander},
 doi = {10.5281/zenodo.4751536},
 month = {5},
 title = {Citation File Format},

--- a/test/converted/complete.bibtex
+++ b/test/converted/complete.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Real_Person_Citation_File_Format_2017,
 author = {Real Person, One Truly and Entity Project Team Conference entity},
 doi = {10.5281/zenodo.1003150},
 month = {12},

--- a/test/converted/complete.bibtex
+++ b/test/converted/complete.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {One Truly Real Person and Entity Project Team Conference entity},
+author = {Real Person, One Truly and Entity Project Team Conference entity},
 doi = {10.5281/zenodo.1003150},
 month = {12},
 title = {Citation File Format 1.0.0},

--- a/test/converted/esalmela_HaploWinder.bibtex
+++ b/test/converted/esalmela_HaploWinder.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Elina Salmela},
+author = {Salmela, Elina},
 doi = {10.5281/zenodo.3901323},
 month = {9},
 title = {HaploWinder},

--- a/test/converted/esalmela_HaploWinder.bibtex
+++ b/test/converted/esalmela_HaploWinder.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Salmela_HaploWinder_2008,
 author = {Salmela, Elina},
 doi = {10.5281/zenodo.3901323},
 month = {9},

--- a/test/converted/example-1.bibtex
+++ b/test/converted/example-1.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Druskat_My_Research_Software_2017,
 author = {Druskat, Stephan},
 doi = {10.5281/zenodo.1234},
 month = {12},

--- a/test/converted/example-1.bibtex
+++ b/test/converted/example-1.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Stephan Druskat},
+author = {Druskat, Stephan},
 doi = {10.5281/zenodo.1234},
 month = {12},
 title = {My Research Software},

--- a/test/converted/ls1mardyn_ls1-mardyn.bibtex
+++ b/test/converted/ls1mardyn_ls1-mardyn.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Boltzmann_Zuse_Society_for_Computational_Molecular_Engineering_ls1_mardyn_2018,
 author = {Boltzmann-Zuse Society for Computational Molecular Engineering},
 month = {9},
 title = {ls1 mardyn},

--- a/test/converted/minimal.bibtex
+++ b/test/converted/minimal.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Robert Haines},
+author = {Haines, Robert},
 month = {7},
 title = {Ruby CFF Library},
 year = {2018}

--- a/test/converted/minimal.bibtex
+++ b/test/converted/minimal.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Haines_Ruby_CFF_Library_2018,
 author = {Haines, Robert},
 month = {7},
 title = {Ruby CFF Library},

--- a/test/converted/short.bibtex
+++ b/test/converted/short.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Robert Haines},
+author = {Haines, Robert},
 month = {7},
 title = {Ruby CFF Library},
 year = {2018}

--- a/test/converted/short.bibtex
+++ b/test/converted/short.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Haines_Ruby_CFF_Library_2018,
 author = {Haines, Robert},
 month = {7},
 title = {Ruby CFF Library},

--- a/test/converted/xenon-middleware_xenon-adaptors-cloud.bibtex
+++ b/test/converted/xenon-middleware_xenon-adaptors-cloud.bibtex
@@ -1,4 +1,4 @@
-@misc{YourReferenceHere,
+@misc{Verhoeven_Cloud_related_adaptors_2019,
 author = {Verhoeven, Stefan and Maassen, Jason and van der Ploeg, Atze},
 doi = {10.5281/zenodo.3245389},
 month = {8},

--- a/test/converted/xenon-middleware_xenon-adaptors-cloud.bibtex
+++ b/test/converted/xenon-middleware_xenon-adaptors-cloud.bibtex
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Stefan Verhoeven and Jason Maassen and Atze van der Ploeg},
+author = {Verhoeven, Stefan and Maassen, Jason and van der Ploeg, Atze},
 doi = {10.5281/zenodo.3245389},
 month = {8},
 title = {Cloud related adaptors for Xenon},


### PR DESCRIPTION
I've added a method to generate a reference for the BibTeX formatter as per the suggestion of @merrygoat in #37.

Some notes:
* I went for `[last name of first author]_[up to first three words of title]_[year]` as the format
* It's robust to there being no year present
* All spaces are converted to `_`
* `-$£%&()+!?\/:;'"~#` are removed

I went for the first three words of the title as just choosing one word could still clash if it was 'A' or 'The' for example.

Would appreciate thoughts from @paxos, @merrygoat and @arfon on this. One question would be: should I lowercase the reference?