### PR TITLE
Reducing json_schema dependency to ~0.20.0

### DIFF
--- a/cff.gemspec
+++ b/cff.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_runtime_dependency 'json_schema', '~> 0.21.0'
+  spec.add_runtime_dependency 'json_schema', '~> 0.20.0'
   spec.add_runtime_dependency 'language_list', '~> 1.2'
   spec.add_runtime_dependency 'spdx-licenses', '~> 1.3'
 


### PR DESCRIPTION
:wave: @hainesr – Unfortunately the `~0.21.0` dependency here is causing some issues in `github/github` which are going to take a little while to resolve. 

In order to be able to update the gem this week in GitHub, this PR simply lowers the `json_schema` version we're depending upon here.

I'm pretty sure this change is benign, and we'll be sure to bump the `github/github` version in time 😸  