### PR TITLE
Prevent errors when cff is passed explicit nils

### DIFF
--- a/lib/cff/model.rb
+++ b/lib/cff/model.rb
@@ -71,16 +71,15 @@ module CFF
     def initialize(param)
       if param.is_a?(Hash)
         @fields = build_model(param)
-        @fields.default = ''
       else
-        @fields = Hash.new('')
+        @fields = {}
         @fields['cff-version'] = DEFAULT_SPEC_VERSION
         @fields['message'] = DEFAULT_MESSAGE
         @fields['title'] = param
       end
 
       %w[authors contact identifiers keywords references].each do |field|
-        @fields[field] = [] if @fields[field].empty?
+        @fields[field] = [] if @fields[field].nil? || @fields[field].empty?
       end
 
       yield self if block_given?

--- a/lib/cff/model_part.rb
+++ b/lib/cff/model_part.rb
@@ -35,7 +35,7 @@ module CFF
       if n.end_with?('=')
         @fields[n.chomp('=')] = args[0] || ''
       else
-        @fields[n]
+        @fields[n].nil? ? '' : @fields[n]
       end
     end
 

--- a/lib/cff/reference.rb
+++ b/lib/cff/reference.rb
@@ -145,9 +145,8 @@ module CFF
     def initialize(param, *more) # rubocop:disable Metrics/AbcSize
       if param.is_a?(Hash)
         @fields = build_model(param)
-        @fields.default = ''
       else
-        @fields = Hash.new('')
+        @fields = {}
         type = more[0] &&= more[0].downcase
         @fields['type'] = REFERENCE_TYPES.include?(type) ? type : 'generic'
         @fields['title'] = param
@@ -157,7 +156,7 @@ module CFF
         'authors', 'contact', 'editors', 'editors-series', 'identifiers',
         'keywords', 'patent-states', 'recipients', 'senders', 'translators'
       ].each do |field|
-        @fields[field] = [] if @fields[field].empty?
+        @fields[field] = [] if @fields[field].nil? || @fields[field].empty?
       end
 
       yield self if block_given?
@@ -193,12 +192,12 @@ module CFF
     # three letter language code, so `GER` becomes `deu`, `french` becomes
     # `fra` and `en` becomes `eng`.
     def add_language(lang)
-      @fields['languages'] = [] if @fields['languages'].empty?
+      @fields['languages'] = [] if @fields['languages'].nil? || @fields['languages'].empty?
       lang = LanguageList::LanguageInfo.find(lang)
       return if lang.nil?
 
       lang = lang.iso_639_3
-      @fields['languages'] << lang unless @fields['languages'].include? lang
+      @fields['languages'] << lang unless @fields['languages'].include?(lang)
     end
 
     # :call-seq:
@@ -214,7 +213,7 @@ module CFF
     #
     # Return the list of languages associated with this Reference.
     def languages
-      @fields['languages'].empty? ? [] : @fields['languages'].dup
+      @fields['languages'].nil? || @fields['languages'].empty? ? [] : @fields['languages'].dup
     end
 
     # :call-seq:
@@ -266,7 +265,7 @@ module CFF
     # This method is explicitly defined to override the private format method
     # that all objects seem to have.
     def format # :nodoc:
-      @fields['format']
+      @fields['format'].nil? ? '' : @fields['format']
     end
 
     # Sets the format of this Reference.

--- a/test/cff_model_test.rb
+++ b/test/cff_model_test.rb
@@ -395,4 +395,14 @@ class CFFModelTest < Minitest::Test
     m = ::CFF::Model.new('title')
     refute_empty(m)
   end
+
+  def test_handles_explicit_nil
+    m = ::CFF::Model.new({ 'title' => 'hi', 'keywords' => nil })
+    refute_empty(m)
+  end
+
+  def test_handles_nil_in_yaml
+    m = ::CFF::Model.read('title: hi\nkeywords:\n')
+    refute_empty(m)
+  end
 end


### PR DESCRIPTION
Before this change, the default on field caches is set to empty string.
This allows calling methods like .empty? on keys that where never explicitly set.
This works well in most cases, however it is really easy to have explictly nil keys which default will not override.
Instead we can handle explicit nils when reading the keys and assure that explicit and implicit nils are treated the same.