### PR TITLE
Only require language list if it is needed

### DIFF
--- a/lib/cff.rb
+++ b/lib/cff.rb
@@ -18,8 +18,6 @@ require 'date'
 require 'json'
 require 'yaml'
 
-require 'language_list'
-
 # This library provides a Ruby interface to manipulate CITATION.cff files. The
 # primary entry points are Model and File.
 #

--- a/lib/cff/reference.rb
+++ b/lib/cff/reference.rb
@@ -192,6 +192,7 @@ module CFF
     # three letter language code, so `GER` becomes `deu`, `french` becomes
     # `fra` and `en` becomes `eng`.
     def add_language(lang)
+      require 'language_list'
       @fields['languages'] = [] if @fields['languages'].nil? || @fields['languages'].empty?
       lang = LanguageList::LanguageInfo.find(lang)
       return if lang.nil?


### PR DESCRIPTION
Language list adds a lot of retrained memory, so for apps that only care reading cff files, it is memory that we can avoid using.

Before this change, requiring the cff gem adds 52517 live slots (memory the GC considers still accessed)

```
before = GC.stat; require "cff"; after = GC.stat; puts "#{after[:heap_live_slots]} - #{before[:heap_live_slots]} = #{after[:heap_live_slots] - before[:heap_live_slots]}"
# => 127916 - 75399 = 52517
```

after this change, requiring cff uses only 1366 live slots

```
before = GC.stat; require "cff"; after = GC.stat; puts "#{after[:heap_live_slots]} - #{before[:heap_live_slots]} = #{after[:heap_live_slots] - before[:heap_live_slots]}"
# => 76663 - 75297 = 1366
```

This saves a significant amount of memory.