### PR TITLE
Small update to gemspec and yaml handling for latest psych and rubocop

### DIFF
--- a/cff.gemspec
+++ b/cff.gemspec
@@ -35,7 +35,8 @@ Gem::Specification.new do |spec|
     'bug_tracker_uri' => 'https://github.com/citation-file-format/ruby-cff/issues',
     'changelog_uri' => 'https://github.com/citation-file-format/ruby-cff/blob/main/CHANGES.md',
     'documentation_uri' => 'https://citation-file-format.github.io/ruby-cff/',
-    'source_code_uri' => 'https://github.com/citation-file-format/ruby-cff'
+    'source_code_uri' => 'https://github.com/citation-file-format/ruby-cff',
+    'rubygems_mfa_required' => 'true'
   }
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/test/cff_file_test.rb
+++ b/test/cff_file_test.rb
@@ -506,13 +506,7 @@ class CFFFileTest < Minitest::Test
     assert_equal(comment, ::CFF::File.parse_comment(file))
   end
 
-  if RUBY_VERSION[0..2].to_f >= 3
-    def load_yaml(file)
-      YAML.safe_load_file(file, permitted_classes: [Date, Time])
-    end
-  else
-    def load_yaml(file)
-      YAML.load_file(file)
-    end
+  def load_yaml(file)
+    YAML.safe_load_file(file, permitted_classes: [Date, Time])
   end
 end


### PR DESCRIPTION
I believe this resolves the test failures I saw in: https://github.com/citation-file-format/ruby-cff/pull/100

they are unrelated to those changes, so I wanted to keep these fixes on their own. Also the `rubygems_mfa_required` rubocop check is great, but you (the maintainer) needs to decide if you are ready to use mfa, not me.