### PR TITLE
Support the `reference.status` indicator in the output formats where appropriate.

### DIFF
--- a/lib/cff/formatter/apa_formatter.rb
+++ b/lib/cff/formatter/apa_formatter.rb
@@ -65,6 +65,8 @@ module CFF
         type_and_school_from_model(model, 'Doctoral dissertation')
       when 'mastersthesis'
         type_and_school_from_model(model, "Master's thesis")
+      when 'unpublished'
+        note_from_model(model) || ''
       else
         ''
       end

--- a/lib/cff/formatter/apa_formatter.rb
+++ b/lib/cff/formatter/apa_formatter.rb
@@ -39,13 +39,14 @@ module CFF
       output.reject(&:empty?).join('. ')
     end
 
-    def self.publication_data_from_model(model) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+    def self.publication_data_from_model(model) # rubocop:disable Metrics
       case model.type
       when 'article'
         [
           model.journal,
           volume_from_model(model),
-          pages_from_model(model, dash: '–')
+          pages_from_model(model, dash: '–'),
+          note_from_model(model) || ''
         ].reject(&:empty?).join(', ')
       when 'book'
         model.publisher.empty? ? '' : model.publisher.name

--- a/lib/cff/formatter/bibtex_formatter.rb
+++ b/lib/cff/formatter/bibtex_formatter.rb
@@ -22,7 +22,7 @@ module CFF
     # Fields without `!` have a simple one-to-one mapping between CFF and
     # BibTeX. Those with `!` call out to a more complex getter.
     ENTRY_TYPE_MAP = {
-      'article' => %w[doi journal number! pages! volume],
+      'article' => %w[doi journal note! number! pages! volume],
       'book' => %w[address! doi editor! isbn number! pages! publisher! volume],
       'booklet' => %w[address! doi],
       'inproceedings' => %w[address! booktitle! doi editor! pages! publisher! series!],

--- a/lib/cff/formatter/bibtex_formatter.rb
+++ b/lib/cff/formatter/bibtex_formatter.rb
@@ -33,7 +33,7 @@ module CFF
       'proceedings' => %w[address! booktitle! doi editor! pages! publisher! series!],
       'software' => %w[doi license version],
       'techreport' => %w[address! doi institution! number!],
-      'unpublished' => %w[doi]
+      'unpublished' => %w[doi note!]
     }.freeze
 
     def self.format(model:, preferred_citation: true) # rubocop:disable Metrics/AbcSize
@@ -53,7 +53,7 @@ module CFF
 
       values['url'] = url(model)
 
-      values['note'] = model.notes unless model.is_a?(Index)
+      values['note'] ||= model.notes unless model.is_a?(Index)
 
       values.reject! { |_, v| v.empty? }
       sorted_values = values.sort.map do |key, value|

--- a/lib/cff/formatter/formatter.rb
+++ b/lib/cff/formatter/formatter.rb
@@ -32,6 +32,13 @@ module CFF
       name.split.map { |part| part[0].capitalize }.join('. ')
     end
 
+    def self.note_from_model(model)
+      case model.status
+      when 'in-preparation'
+        'Manuscript in preparation.'
+      end
+    end
+
     # Prefer `repository_code` over `url`
     def self.url(model)
       model.repository_code.empty? ? model.url : model.repository_code

--- a/lib/cff/formatter/formatter.rb
+++ b/lib/cff/formatter/formatter.rb
@@ -37,7 +37,8 @@ module CFF
       model.repository_code.empty? ? model.url : model.repository_code
     end
 
-    def self.month_and_year_from_model(model)
+    def self.month_and_year_from_model(model) # rubocop:disable Metrics/AbcSize
+      return ['', 'in press'] if model.respond_to?(:status) && model.status == 'in-press'
       if model.respond_to?(:year) && !model.year.to_s.empty?
         return [model.month, model.year].map(&:to_s)
       end

--- a/lib/cff/formatter/formatter.rb
+++ b/lib/cff/formatter/formatter.rb
@@ -36,6 +36,8 @@ module CFF
       case model.status
       when 'in-preparation'
         'Manuscript in preparation.'
+      when 'submitted'
+        'Manuscript submitted for publication.'
       end
     end
 

--- a/lib/cff/formatter/formatter.rb
+++ b/lib/cff/formatter/formatter.rb
@@ -19,6 +19,12 @@ module CFF
   # Formatter base class
   class Formatter # :nodoc:
 
+    STATUS_TEXT_MAP = {
+      'advance-online' => 'Advance online publication',
+      'in-preparation' => 'Manuscript in preparation.',
+      'submitted' => 'Manuscript submitted for publication.'
+    }.freeze
+
     def self.select_and_check_model(model, preferred_citation)
       if preferred_citation && model.preferred_citation.is_a?(Reference)
         model = model.preferred_citation
@@ -33,12 +39,7 @@ module CFF
     end
 
     def self.note_from_model(model)
-      case model.status
-      when 'in-preparation'
-        'Manuscript in preparation.'
-      when 'submitted'
-        'Manuscript submitted for publication.'
-      end
+      STATUS_TEXT_MAP[model.status]
     end
 
     # Prefer `repository_code` over `url`

--- a/test/files/formatted/preferred-citation-advance.apa
+++ b/test/files/formatted/preferred-citation-advance.apa
@@ -1,0 +1,1 @@
+Wickham, H. (2019). Welcome to the Tidyverse. Journal of Open Source Software, Advance online publication. https://doi.org/10.21105/joss.01686

--- a/test/files/formatted/preferred-citation-advance.bibtex
+++ b/test/files/formatted/preferred-citation-advance.bibtex
@@ -1,0 +1,8 @@
+@article{Wickham_Welcome_to_the_2019,
+author = {Wickham, Hadley},
+doi = {10.21105/joss.01686},
+journal = {Journal of Open Source Software},
+note = {Advance online publication},
+title = {{Welcome to the Tidyverse}},
+year = {2019}
+}

--- a/test/files/formatted/preferred-citation-in-prep.apa
+++ b/test/files/formatted/preferred-citation-in-prep.apa
@@ -1,0 +1,1 @@
+Wickham, H. (2019). Welcome to the Tidyverse. Manuscript in preparation.

--- a/test/files/formatted/preferred-citation-in-prep.bibtex
+++ b/test/files/formatted/preferred-citation-in-prep.bibtex
@@ -1,0 +1,6 @@
+@unpublished{Wickham_Welcome_to_the_2019,
+author = {Wickham, Hadley},
+note = {Manuscript in preparation.},
+title = {{Welcome to the Tidyverse}},
+year = {2019}
+}

--- a/test/files/formatted/preferred-citation-in-press.apa
+++ b/test/files/formatted/preferred-citation-in-press.apa
@@ -1,0 +1,1 @@
+Wickham, H. (in press). Welcome to the Tidyverse. Journal of Open Source Software

--- a/test/files/formatted/preferred-citation-in-press.bibtex
+++ b/test/files/formatted/preferred-citation-in-press.bibtex
@@ -1,0 +1,6 @@
+@article{Wickham_Welcome_to_the_in_press,
+author = {Wickham, Hadley},
+journal = {Journal of Open Source Software},
+title = {{Welcome to the Tidyverse}},
+year = {in press}
+}

--- a/test/files/formatted/preferred-citation-submitted.apa
+++ b/test/files/formatted/preferred-citation-submitted.apa
@@ -1,0 +1,1 @@
+Wickham, H. (2019). Welcome to the Tidyverse. Manuscript submitted for publication.

--- a/test/files/formatted/preferred-citation-submitted.bibtex
+++ b/test/files/formatted/preferred-citation-submitted.bibtex
@@ -1,0 +1,6 @@
+@unpublished{Wickham_Welcome_to_the_2019,
+author = {Wickham, Hadley},
+note = {Manuscript submitted for publication.},
+title = {{Welcome to the Tidyverse}},
+year = {2019}
+}

--- a/test/files/formatter/preferred-citation-advance.cff
+++ b/test/files/formatter/preferred-citation-advance.cff
@@ -1,0 +1,26 @@
+# Note this is a made up entry.
+
+cff-version: 1.2.0
+message: If you use this software in your work, please cite it using the following metadata
+title: Tidyverse
+authors:
+- family-names: Wickham
+  given-names: Hadley
+  orcid: https://orcid.org/0000-0003-4757-117X
+version: 1.3.1
+date-released: 2021-04-15
+license: MIT
+repository-artifact: https://github.com/tidyverse/tidyverse
+
+# JOSS paper as preferred citation
+preferred-citation:
+  authors:
+    - family-names: Wickham
+      given-names: Hadley
+      orcid: https://orcid.org/0000-0003-4757-117X
+  doi: "10.21105/joss.01686"
+  journal: "Journal of Open Source Software"
+  title: "Welcome to the Tidyverse"
+  type: article
+  status: advance-online
+  year: 2019

--- a/test/files/formatter/preferred-citation-in-prep.cff
+++ b/test/files/formatter/preferred-citation-in-prep.cff
@@ -1,0 +1,24 @@
+# Note this is a made up entry.
+
+cff-version: 1.2.0
+message: If you use this software in your work, please cite it using the following metadata
+title: Tidyverse
+authors:
+- family-names: Wickham
+  given-names: Hadley
+  orcid: https://orcid.org/0000-0003-4757-117X
+version: 1.3.1
+date-released: 2021-04-15
+license: MIT
+repository-artifact: https://github.com/tidyverse/tidyverse
+
+# JOSS paper as preferred citation
+preferred-citation:
+  authors:
+    - family-names: Wickham
+      given-names: Hadley
+      orcid: https://orcid.org/0000-0003-4757-117X
+  title: "Welcome to the Tidyverse"
+  type: unpublished
+  status: in-preparation
+  year: 2019

--- a/test/files/formatter/preferred-citation-in-press.cff
+++ b/test/files/formatter/preferred-citation-in-press.cff
@@ -1,0 +1,25 @@
+# Note this is a made up entry.
+
+cff-version: 1.2.0
+message: If you use this software in your work, please cite it using the following metadata
+title: Tidyverse
+authors:
+- family-names: Wickham
+  given-names: Hadley
+  orcid: https://orcid.org/0000-0003-4757-117X
+version: 1.3.1
+date-released: 2021-04-15
+license: MIT
+repository-artifact: https://github.com/tidyverse/tidyverse
+
+# JOSS paper as preferred citation
+preferred-citation:
+  authors:
+    - family-names: Wickham
+      given-names: Hadley
+      orcid: https://orcid.org/0000-0003-4757-117X
+  journal: "Journal of Open Source Software"
+  title: "Welcome to the Tidyverse"
+  type: article
+  status: in-press
+  year: 2019

--- a/test/files/formatter/preferred-citation-submitted.cff
+++ b/test/files/formatter/preferred-citation-submitted.cff
@@ -1,0 +1,24 @@
+# Note this is a made up entry.
+
+cff-version: 1.2.0
+message: If you use this software in your work, please cite it using the following metadata
+title: Tidyverse
+authors:
+- family-names: Wickham
+  given-names: Hadley
+  orcid: https://orcid.org/0000-0003-4757-117X
+version: 1.3.1
+date-released: 2021-04-15
+license: MIT
+repository-artifact: https://github.com/tidyverse/tidyverse
+
+# JOSS paper as preferred citation
+preferred-citation:
+  authors:
+    - family-names: Wickham
+      given-names: Hadley
+      orcid: https://orcid.org/0000-0003-4757-117X
+  title: "Welcome to the Tidyverse"
+  type: unpublished
+  status: submitted
+  year: 2019


### PR DESCRIPTION
This PR fixes #108 and part of #106.

This change adds support for most settings of the `reference.status` field to the output formatters:
* `in-press`
* `submitted`
* `in-preparation`
* `advance-online`

For the APA-like formatter I used the following advice for how to format the various scenarios: https://blog.apastyle.org/apastyle/2012/08/almost-published.html