### PR TITLE
Ensure that `Date`s are either parsed or `dup`ed when passed in to date fields.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,3 +67,6 @@ Metrics/ClassLength:
 # This is still too high, but we'll get there.
 Minitest/MultipleAssertions:
   Max: 10
+
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true

--- a/lib/cff/entity.rb
+++ b/lib/cff/entity.rb
@@ -45,6 +45,8 @@ module CFF
     # :nodoc:
     ALLOWED_FIELDS = SCHEMA_FILE['definitions']['entity']['properties'].keys.freeze
 
+    attr_date :date_end, :date_start
+
     # :call-seq:
     #   new(name) -> Entity
     #   new(name) { |entity| block } -> Entity
@@ -61,28 +63,6 @@ module CFF
       end
 
       yield self if block_given?
-    end
-
-    # :call-seq:
-    #   date_end = date
-    #
-    # Set the `date-end` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_end=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-end'] = date
-    end
-
-    # :call-seq:
-    #   date_start = date
-    #
-    # Set the `date-start` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_start=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-start'] = date
     end
   end
 end

--- a/lib/cff/index.rb
+++ b/lib/cff/index.rb
@@ -56,6 +56,8 @@ module CFF
     DEFAULT_MESSAGE = 'If you use this software in your work, please cite ' \
                       'it using the following metadata'
 
+    attr_date :date_released
+
     # :call-seq:
     #   new(title) -> Index
     #   new(title) { |index| block } -> Index
@@ -101,17 +103,6 @@ module CFF
       yield cff if block_given?
 
       cff
-    end
-
-    # :call-seq:
-    #   date_released = date
-    #
-    # Set the `date-released` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_released=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-released'] = date
     end
 
     # :call-seq:

--- a/lib/cff/model_part.rb
+++ b/lib/cff/model_part.rb
@@ -54,5 +54,26 @@ module CFF
     def empty?
       false
     end
+
+    def self.attr_date(*symbols) # :nodoc:
+      symbols.each do |symbol|
+        field = symbol.to_s.tr('_', '-')
+
+        class_eval(
+          # def date_end=(date)
+          #   date = (date.is_a?(Date) ? date.dup : Date.parse(date))
+          #
+          #   @fields['date-end'] = date
+          # end
+          <<-END_SETTER, __FILE__, __LINE__ + 1
+            def #{symbol}=(date)
+              date = (date.is_a?(Date) ? date.dup : Date.parse(date))
+
+              @fields['#{field}'] = date
+            end
+          END_SETTER
+        )
+      end
+    end
   end
 end

--- a/lib/cff/reference.rb
+++ b/lib/cff/reference.rb
@@ -106,6 +106,9 @@ module CFF
     REFERENCE_STATUS_TYPES =
       SCHEMA_FILE['definitions']['reference']['properties']['status']['enum'].dup.freeze
 
+    attr_date :date_accessed, :date_downloaded, :date_published,
+              :date_released, :issue_date
+
     # :call-seq:
     #   new(title) -> Reference
     #   new(title) { |ref| block } -> Reference
@@ -191,50 +194,6 @@ module CFF
     # Return the list of languages associated with this Reference.
     def languages
       @fields['languages'].nil? || @fields['languages'].empty? ? [] : @fields['languages'].dup
-    end
-
-    # :call-seq:
-    #   date_accessed = date
-    #
-    # Set the `date-accessed` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_accessed=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-accessed'] = date
-    end
-
-    # :call-seq:
-    #   date_downloaded = date
-    #
-    # Set the `date-downloaded` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_downloaded=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-downloaded'] = date
-    end
-
-    # :call-seq:
-    #   date_published = date
-    #
-    # Set the `date-published` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_published=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-published'] = date
-    end
-
-    # :call-seq:
-    #   date_released = date
-    #
-    # Set the `date-released` field. If a non-Date object is passed in it will
-    # be parsed into a Date.
-    def date_released=(date)
-      date = Date.parse(date) unless date.is_a?(Date)
-
-      @fields['date-released'] = date
     end
 
     # Returns the format of this Reference.

--- a/test/cff_reference_test.rb
+++ b/test/cff_reference_test.rb
@@ -172,7 +172,7 @@ class CFFReferenceTest < Minitest::Test
 
   def test_dates_are_set_and_output_correctly
     %w[
-      date_accessed date_downloaded date_published date_released
+      date_accessed date_downloaded date_published date_released issue_date
     ].each do |method|
       date = Date.today
       @reference.send("#{method}=", date)
@@ -234,7 +234,6 @@ class CFFReferenceTest < Minitest::Test
       format
       isbn
       issn
-      issue_date
       issue_title
       journal
       license_url


### PR DESCRIPTION
Add code to `ModelPart` to quickly define date setters, and then use it to set dates across the CFF model.

This change means:
 * we don't have loads of repeated code; and
 * we can dup Date objects to avoid dereferencing (as in #113).

It's worth fixing this issue this way (i.e. doing all the `dup`ing) so that users don't need to worry about using the same `Date` instance for multiple date fields. The YAML output without this change is valid, of course, but it becomes less human-readable.

Fixes #113